### PR TITLE
version should be 2.0.0, not '2.0.0'

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0"
+version = 2.0.0
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2


### PR DESCRIPTION
Fixes:
```
[error] failed to resolve Scalafmt version '2.0.0': /home/lglo/projects/interop-scalaz/.scalafmt.conf
```