### PR TITLE
Update to RC13, remove core-tests dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,13 +45,13 @@ lazy val interopScalaz7x = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"    %%% "zio"                       % "1.0.0-RC11-1",
-      "org.scalaz" %%% "scalaz-core"               % "7.2.+" % Optional,
-      "dev.zio"    %%% "core-tests"                % "1.0.0-RC11-1" % Test classifier "tests",
-      "org.specs2" %%% "specs2-core"               % "4.7.0" % Test,
-      "org.specs2" %%% "specs2-scalacheck"         % "4.7.0" % Test,
-      "org.specs2" %%% "specs2-matcher-extra"      % "4.7.0" % Test,
-      "org.scalaz" %%% "scalaz-scalacheck-binding" % "7.2.+" % Test
+      "dev.zio"        %%% "zio"                       % "1.0.0-RC13",
+      "org.scalaz"     %%% "scalaz-core"               % "7.2.+" % Optional,
+      "org.specs2"     %%% "specs2-core"               % "4.7.1" % Test,
+      "org.specs2"     %%% "specs2-scalacheck"         % "4.7.1" % Test,
+      "org.specs2"     %%% "specs2-matcher-extra"      % "4.7.1" % Test,
+      "org.scalaz"     %%% "scalaz-scalacheck-binding" % "7.2.+" % Test,
+      "org.scalacheck" %%% "scalacheck"                % "1.14.1" % Test
     )
   )
 

--- a/interop-scalaz7x/jvm/src/test/scala/zio/interop/scalazPlatform72Spec.scala
+++ b/interop-scalaz7x/jvm/src/test/scala/zio/interop/scalazPlatform72Spec.scala
@@ -1,17 +1,15 @@
 package zio
 package interop
 
-import org.scalacheck.{ Arbitrary, Cogen }
-import org.specs2.ScalaCheck
+import org.scalacheck.{ Arbitrary, Cogen, _ }
+import org.specs2.{ ScalaCheck, Specification }
 import scalaz.Scalaz._
 import scalaz.scalacheck.ScalazProperties._
-import zio.interop.scalaz72._
 import scalaz._
+import zio.interop.scalaz72._
+import zio.internal.PlatformLive
 
-class scalazPlatform72Spec(implicit ee: org.specs2.concurrent.ExecutionEnv)
-    extends TestRuntime
-    with ScalaCheck
-    with GenIO {
+class scalazPlatform72Spec extends Specification with ScalaCheck with GenIO {
 
   def is = s2"""
     laws must hold for
@@ -23,11 +21,18 @@ class scalazPlatform72Spec(implicit ee: org.specs2.concurrent.ExecutionEnv)
       MonadError             ${monadError.laws[IO[Int, ?], Int]}
       Applicative (Parallel) ${applicative.laws[scalaz72.ParIO[Any, Int, ?]]}
   """
+  type Env = Any
+
+  private val rts: Runtime[Env] = new DefaultRuntime {
+    override val Platform = PlatformLive
+      .makeDefault()
+      .withReportFailure(_ => ())
+  }
 
   implicit def ioEqual[E: Equal, A: Equal]: Equal[IO[E, A]] =
     new Equal[IO[E, A]] {
       override def equal(io1: IO[E, A], io2: IO[E, A]): Boolean =
-        unsafeRun(io1.either) === unsafeRun(io2.either)
+        rts.unsafeRun(io1.either) === rts.unsafeRun(io2.either)
     }
 
   implicit def ioArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[IO[E, A]] =
@@ -38,4 +43,46 @@ class scalazPlatform72Spec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   implicit def ioParArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[scalaz72.ParIO[Any, E, A]] =
     Arbitrary(genIO[E, A].map(Tag.apply))
+}
+
+trait GenIO {
+
+  /**
+   * Given a generator for `A`, produces a generator for `IO[E, A]` using the `IO.point` constructor.
+   */
+  def genSyncSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Arbitrary.arbitrary[A].map(IO.succeed[A](_))
+
+  /**
+   * Given a generator for `A`, produces a generator for `IO[E, A]` using the `IO.async` constructor.
+   */
+  def genAsyncSuccess[E, A: Arbitrary]: Gen[IO[E, A]] =
+    Arbitrary.arbitrary[A].map(a => IO.effectAsync[E, A](k => k(IO.succeed(a))))
+
+  /**
+   * Randomly uses either `genSyncSuccess` or `genAsyncSuccess` with equal probability.
+   */
+  def genSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Gen.oneOf(genSyncSuccess[E, A], genAsyncSuccess[E, A])
+
+  /**
+   * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.fail` constructor.
+   */
+  def genSyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Arbitrary.arbitrary[E].map(IO.fail[E])
+
+  /**
+   * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.async` constructor.
+   */
+  def genAsyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] =
+    Arbitrary.arbitrary[E].map(err => IO.effectAsync[E, A](k => k(IO.fail(err))))
+
+  /**
+   * Randomly uses either `genSyncFailure` or `genAsyncFailure` with equal probability.
+   */
+  def genFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Gen.oneOf(genSyncFailure[E, A], genAsyncFailure[E, A])
+
+  /**
+   * Randomly uses either `genSuccess` or `genFailure` with equal probability.
+   */
+  def genIO[E: Arbitrary, A: Arbitrary]: Gen[IO[E, A]] =
+    Gen.oneOf(genSuccess[E, A], genFailure[E, A])
+
 }

--- a/interop-scalaz7x/shared/src/main/scala/zio/interop/scalaz72.scala
+++ b/interop-scalaz7x/shared/src/main/scala/zio/interop/scalaz72.scala
@@ -53,7 +53,7 @@ sealed trait ZIOInstances2 {
 
 private class ZIOMonad[R, E] extends Monad[ZIO[R, E, ?]] with BindRec[ZIO[R, E, ?]] {
   override def map[A, B](fa: ZIO[R, E, A])(f: A => B): ZIO[R, E, B]             = fa.map(f)
-  override def point[A](a: => A): ZIO[R, E, A]                                  = ZIO.succeedLazy(a)
+  override def point[A](a: => A): ZIO[R, E, A]                                  = ZIO.effectTotal(a)
   override def bind[A, B](fa: ZIO[R, E, A])(f: A => ZIO[R, E, B]): ZIO[R, E, B] = fa.flatMap(f)
   override def tailrecM[A, B](f: A => ZIO[R, E, A \/ B])(a: A): ZIO[R, E, B] =
     f(a).flatMap(_.fold(tailrecM(f), point(_)))
@@ -85,7 +85,7 @@ private trait ZIOBifunctor[R] extends Bifunctor[ZIO[R, ?, ?]] {
 }
 
 private class ZIOParApplicative[R, E] extends Applicative[scalaz72.ParIO[R, E, ?]] {
-  override def point[A](a: => A): scalaz72.ParIO[R, E, A] = Tag(ZIO.succeedLazy(a))
+  override def point[A](a: => A): scalaz72.ParIO[R, E, A] = Tag(ZIO.effectTotal(a))
   override def ap[A, B](fa: => scalaz72.ParIO[R, E, A])(f: => scalaz72.ParIO[R, E, A => B]): scalaz72.ParIO[R, E, B] = {
     lazy val fa0: ZIO[R, E, A] = Tag.unwrap(fa)
     Tag(Tag.unwrap(f).flatMap(x => fa0.map(x)))

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -7,8 +7,7 @@ import sbtbuildinfo._
 import BuildInfoKeys._
 
 object ScalazBuild {
-  val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.0" % "test")
-  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.2"  % "provided")
+  val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.2" % "provided")
 
   private val stdOptions = Seq(
     "-deprecation",
@@ -76,7 +75,7 @@ object ScalazBuild {
     crossScalaVersions := Seq("2.12.8", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value),
-    libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(
+    libraryDependencies ++= compileOnlyDeps ++ Seq(
       compilerPlugin("org.typelevel"   %% "kind-projector"  % "0.10.3"),
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2")
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "0.6.28")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "0.6.29")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "0.6.1")
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"              % "2.0.3")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"              % "2.0.5")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"             % "0.9.0")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"             % "1.6.0")
 addSbtPlugin("ch.epfl.scala"      % "sbt-release-early"         % "2.1.1")


### PR DESCRIPTION
I c-p GenIO and removed parts that are not used in scalaz7x tests